### PR TITLE
Remove extension filtering

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 import { createFilter } from 'rollup-pluginutils';
 import MagicString from 'magic-string'
 
-const ext = /\.glsl$/;
-
 function compressShader(source) {
   let needNewline = false;
   return source.replace(/\/\*.*?\*\//g, "").split(/\n+/).reduce((result, line) => {
@@ -35,7 +33,6 @@ export default function glsl(options = {}) {
 		name: 'glsl',
 
 		transform(source, id) {
-			if (!ext.test(id)) return;
 			if (!filter(id)) return;
 
 			const code = generateCode(compressShader(source)),


### PR DESCRIPTION
As I described in https://github.com/vwochnik/rollup-plugin-glsl/issues/1, I believe filtering the shaders by extension is counter-intuitive and can break the usual workflow of some users.

I think filtering of files should be done by the `include` and `exclude` options in the plugin config instead.

Let me know what you think about this change.