### PR TITLE
upgrade rollup-pluginutils to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dist"
   ],
   "dependencies": {
-    "rollup-pluginutils": "^1.5.0",
+    "rollup-pluginutils": "^2.0.1",
     "magic-string": "^0.21.3"
   },
   "devDependencies": {


### PR DESCRIPTION
I was having some issues with .glsl files in a symlinked dependency project not being loaded.  Globs were limited to the root folder. Latest version of rollup-pluginutils does not limit the glob.