### PR TITLE
Remove multiline comments with compress option

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ import MagicString from 'magic-string'
 
 function compressShader(source) {
   let needNewline = false;
-  return source.replace(/\\(?:\r\n|\n\r|\n|\r)|\/\*.*?\*\/|\/\/(?:\\(?:\r\n|\n\r|\n|\r)|[^\n\r])*/g, "").split(/\n+/).reduce((result, line) => {
+  return source.replace(/\\(?:\r\n|\n\r|\n|\r)|\/\*.*?\*\/|\/\/(?:\\(?:\r\n|\n\r|\n|\r)|[^\n\r])*/gs, "").split(/\n+/).reduce((result, line) => {
     line = line.trim().replace(/\s{2,}|\t/, " ");
     if (line[0] === '#') {
       if (needNewline) {


### PR DESCRIPTION
Currently multiline comments are not removed because `.` doesn't match `\n`.

`s` regex modifier is required for `.` to match `\n`.